### PR TITLE
Marquee - Set width to message

### DIFF
--- a/marquee/lwc/marquee.css
+++ b/marquee/lwc/marquee.css
@@ -1,67 +1,75 @@
 .marquee {
     --default-background: rgb(186, 5, 23);
     --default-height: 40px;
-}
-
-.marquee {
+  }
+  
+  .marquee {
     width: 100%;
-
+  
     background: var(--background, var(--default-background));
     padding: 8px;
     font-size: 16px;
     font-family: sans-serif;
-
+  
     height: var(--height, var(--default-height));
     display: flex;
     align-items: center;
-}
-
-.marquee--content {
+  }
+  
+  .marquee--content {
     width: 90%;
     max-width: 1120px;
     margin: 0 auto;
-
+  
     display: flex;
-
+  
     overflow: hidden;
-}
-
-ul {
+  }
+  
+  ul {
     padding: 0 16px;
     white-space: nowrap;
     flex: none;
     list-style: none;
-}
-
-li {
+    
+    min-width: 100%;
+  }
+  
+  li {
     display: inline-block;
-    animation: scroll 30s linear infinite;
+    animation: scroll 20s linear infinite;
     padding: 0 16px;
-
+  
     color: #fff;
-
+  
+    width: 100%;
+  }
+  
+  li span {
+    display: inline-block;
     position: relative;
-}
-
-li:after {
-    content: '';
+  }
+  
+  li span:after {
+    content: "";
     display: block;
     position: absolute;
     width: 8px;
     height: 8px;
     background: #fff;
-    right: -16px;
+    right: -36px;
     top: 50%;
     transform: translateY(-50%);
     border-radius: 50%;
-}
-
-@keyframes scroll {
+  }
+  
+  @keyframes scroll {
     0% {
-        transform: translate3d(0, 0, 0);
+      transform: translate3d(0, 0, 0);
     }
-
+  
     100% {
-        transform: translate3d(-100%, 0, 0);
+      transform: translate3d(-100%, 0, 0);
     }
-}
+  }
+  

--- a/marquee/lwc/marquee.html
+++ b/marquee/lwc/marquee.html
@@ -3,11 +3,15 @@
         <div class="marquee--content">
             <template lwc:if={message}>
                 <ul>
-                    <li>{message}</li>
+                    <li>
+                        <span>{message}</span>
+                    </li>
                 </ul>
 
                 <ul>
-                    <li>{message}</li>
+                    <li>
+                        <span>{message}</span>
+                    </li>
                 </ul>
             </template>
         </div>


### PR DESCRIPTION
Change width of message element to avoid glitch for short message when animation resets to initial position at the end.
Wrap message in span to preserve dot styling in :after pseudo element.